### PR TITLE
fix: resolve path duplication in resolve_path_loaddata function

### DIFF
--- a/starrynight/src/starrynight/utils/misc.py
+++ b/starrynight/src/starrynight/utils/misc.py
@@ -57,10 +57,15 @@ def resolve_path_loaddata(
     #     print(
     #         f"Absolute path:{path_mask.resolve().__str__().rstrip('/')}/{filepath.__str__().lstrip('/')}/"
     #     )
-    if filepath.is_absolute():
-        return filepath
-    else:
-        return f"{path_mask.resolve().__str__().rstrip('/')}/{filepath.__str__().lstrip('/')}/"
+    try:
+        # Try to see if filepath is already under path_mask
+        filepath.resolve().relative_to(path_mask.resolve())
+        # If successful, filepath is already under path_mask, return it resolved
+        return str(filepath.resolve())
+    except ValueError:
+        # If filepath is not under path_mask, concatenate them
+        # Use proper path joining instead of string manipulation
+        return str(path_mask.resolve() / filepath)
 
 
 def write_pq(


### PR DESCRIPTION
## Summary

Fixes the path duplication issue in `resolve_path_loaddata()` where overlapping directory structures caused double nesting (e.g., `/scratch/scratch/`) when using relative paths.

## Problem

The current implementation in `starrynight/src/starrynight/utils/misc.py` only checks `filepath.is_absolute()` but doesn't detect when `filepath` contains overlapping path components with `path_mask`. This leads to path duplication when joining them.

**Example of the bug:**
- `path_mask`: `./scratch/fix_s1_output/workspace`  
- `filepath`: `./scratch/fix_s1_output/workspace/illum/sbs/illum_apply/`
- **Current result**: `/Users/.../scratch/scratch/fix_s1_output/workspace/illum/sbs/illum_apply/` ❌
- **Fixed result**: `/Users/.../scratch/fix_s1_output/workspace/illum/sbs/illum_apply/` ✅

## Solution

Replace the simple absolute path check with smart overlap detection using `relative_to()`:

1. **Detect overlapping paths**: Check if `filepath` is already under `path_mask` using `relative_to()`
2. **Prevent duplication**: If overlap detected, return resolved `filepath` directly
3. **Proper path joining**: Use pathlib operations instead of string manipulation
4. **Fix double slash bug**: Eliminate trailing `//` in results

## Changes

```python
# Before (broken)
if filepath.is_absolute():
    return filepath
else:
    return f"{path_mask.resolve().__str__().rstrip('/')}/{filepath.__str__().lstrip('/')}/"

# After (fixed) 
try:
    # Try to see if filepath is already under path_mask
    filepath.resolve().relative_to(path_mask.resolve())
    # If successful, filepath is already under path_mask, return it resolved
    return str(filepath.resolve())
except ValueError:
    # If filepath is not under path_mask, concatenate them
    # Use proper path joining instead of string manipulation
    return str(path_mask.resolve() / filepath)
```

## Testing

- ✅ All existing tests pass (59 passed, 1 skipped)
- ✅ Resolves the specific scenario from Issue #131
- ✅ Handles absolute paths correctly  
- ✅ Handles relative paths correctly
- ✅ Prevents path duplication
- ✅ Eliminates double slash bug

## Impact

This fixes the CLI workflow documented in `docs/user/example-pipeline-cli.md` when using relative paths, particularly affecting:
- `preprocess.py` commands
- `analysis.py` commands  
- `segcheck.py` commands
- `align.py` commands

Fixes #131

🤖 Generated with [Claude Code](https://claude.ai/code)